### PR TITLE
fix stop score in viterbi

### DIFF
--- a/model.py
+++ b/model.py
@@ -89,6 +89,10 @@ class CRF(nn.Module):
 
             mask = (c_lens > 0).float().unsqueeze(-1).expand_as(vit_nxt)
             vit = mask * vit_nxt + (1 - mask) * vit
+
+            mask = (c_lens == 1).float().unsqueeze(-1).expand_as(vit_nxt)
+            vit += mask * self.transitions[ self.stop_idx ].unsqueeze(0).expand_as(vit_nxt)
+
             c_lens = c_lens - 1
 
         pointers = torch.cat(pointers)


### PR DESCRIPTION
According to the Pytorch tutorial, we need to add the stop transition score in Viterbi.
See the following code:
https://github.com/pytorch/tutorials/blob/master/beginner_source/nlp/advanced_tutorial.py#L269

Really thanks to your code, it helps me a lot.
